### PR TITLE
Update event system dependency and handler registration

### DIFF
--- a/dyingstar_props/Cargo.toml
+++ b/dyingstar_props/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 # Event system (CLI will update this to horizon_event_system)
-horizon_event_system = { path = "../Horizon/crates/horizon_event_system" }
+horizon_event_system = "0.14.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.0", features = ["full"] }

--- a/dyingstar_props/src/lib.rs
+++ b/dyingstar_props/src/lib.rs
@@ -188,18 +188,16 @@ impl SimplePlugin for DyingstarPropsPlugin {
         // Setup GORC handlers
         self.setup_gorc_handlers(events.clone()).await?;
 
-        register_handlers!(events; client {
-            "box50cm", "spawn" => |event: serde_json::Value| {
-                println!("Received prop event: {:?}", event);
-                // let box50cm = Box50cm::new(Vec3::new(500.0, 100.0, 300.0), Vec3::new(0.0, 0.0, 0.0));
-                // let box50cm_id = "box50cm_001".to_string();
-                // {
-                //     let mut boxes50cm = self.boxes50cm.write();
-                //     boxes50cm.insert(box50cm_id.clone(), box50cm.clone());
-                // }
-                Ok(())
-            }
-        })?;
+        events.on_client("box50cm", "spawn", |event: serde_json::Value| {
+            println!("Received prop event: {:?}", event);
+            // let box50cm = Box50cm::new(Vec3::new(500.0, 100.0, 300.0), Vec3::new(0.0, 0.0, 0.0));
+            // let box50cm_id = "box50cm_001".to_string();
+            // {
+            //     let mut boxes50cm = self.boxes50cm.write();
+            //     boxes50cm.insert(box50cm_id.clone(), box50cm.clone());
+            // }
+            Ok(())
+        }).await.unwrap();
         
         info!("🔧 DyingstarPropsPlugin: ✅ All handlers registered successfully!");
         Ok(())


### PR DESCRIPTION
Changed horizon_event_system dependency from a local path to version 0.14.0 in Cargo.toml. Refactored event handler registration in lib.rs to use events.on_client instead of register_handlers! macro for improved clarity and to fix registration bugs