### PR TITLE
Mining V0 server: replicate player properties and spawn game-server props

### DIFF
--- a/ds_genericprops/src/lib.rs
+++ b/ds_genericprops/src/lib.rs
@@ -293,7 +293,11 @@ impl GenericPropsPlugin {
                                 update_events3.clone(),
                                 event.clone(),
                                 handle3.clone(),
-                                false,
+                                // Spawn the game-server-requested object in the game server too: it
+                                // does not exist there yet (e.g. a mining rock side2). Without this
+                                // it is only registered in GORC + sent to clients, so the game
+                                // server can neither simulate nor re-cut it.
+                                true,
                                 queue_objects_create3.clone(),
                             )
                         {


### PR DESCRIPTION
## PR 2 — `DyingStar-game/horizonserver` : `feat/mining-side2-spawn` → `develop`

**Title:** `Mining V0 server: replicate player properties and spawn game-server props`

**Body:**
```markdown
## What
Server side of mining V0 (paired with the DyingStar client PR). Two changes:

### 1. Generic player property replication (`players/update`)
In `ds_game_server/src/server.rs` the inbound `players` / `"update"` branch was a stub,
so generic player properties were never replicated. It now routes to the genericprops
`update_object` handler (a new `GameServerMessage::PlayerUpdate` forwards the event from
the ws reader to the async processor), merging the properties into the player's GORC
object and broadcasting them to nearby clients per `player_def.json`. `player_def.json`
gains `tools`, `head`, `perforating` (equipped tool, camera pitch, drilling state) so
other players see the perforator.

### 2. Spawn game-server-requested objects in the game server
In `ds_genericprops`, `create_object_from_gameserver` now uses `spawn_in_gameserver = true`,
so an object the game server asks Horizon to create (e.g. a mining rock's broken-off half
/ side2) is spawned back in the game server too, not only registered in GORC and sent to
clients. Without it the game server never instantiated it, so it could neither simulate
nor re-cut it (the side2 stayed uncuttable, capping mining at 3 pieces). The game
server's own `props/create_object` is the only user of this path.

## Build note (out of scope)
On Windows checkouts the `*.sh` scripts come out as CRLF and break the Docker build
(`scripts/build.sh` → exit 127) and the runtime `entrypoint.sh`. A `.gitattributes`
with `*.sh text eol=lf` would fix this for everyone.