### PR TITLE
Add a 'carrying' player property for replication (issue #124)

### DIFF
--- a/ds_genericprops/props/player_def.json
+++ b/ds_genericprops/props/player_def.json
@@ -12,6 +12,7 @@
 				"tools",
 				"head",
 				"perforating",
+				"carrying",
 				"scenename",
 				"name",
 				"parent_id",


### PR DESCRIPTION
Replicated like tools/head/perforating: the game server sets it while a player carries an ore, and clients use it to stow that player's perforator.

