### PR TITLE
Feat/player carrying prop

### DIFF
--- a/.docker/plugins.toml
+++ b/.docker/plugins.toml
@@ -64,6 +64,7 @@ subscribe = [
     "plugin:genericprops:create_object_from_gameserver",
     "plugin:genericprops:update_object",
     "plugin:genericprops:update_object_from_external",
+    "plugin:genericprops:delete_object",
     "plugin:bridge_persistence:get_all_items",
     "plugin:bridge_persistence:player_spawn",
 ]

--- a/ds_genericprops/props/mining_depot_def.json
+++ b/ds_genericprops/props/mining_depot_def.json
@@ -1,0 +1,24 @@
+{
+	"channels": [
+		{
+			"zone": 0,
+			"distance": 100.0,
+			"frequency": 30.0,
+			"properties": [
+				"position",
+				"rotation",
+				"scenename",
+				"parent_id"
+			]
+		},
+		{
+			"zone": 6,
+			"distance": 100.0,
+			"frequency": 5.0,
+			"properties": [
+				"scenename",
+				"data"
+			]
+		}
+	]
+}

--- a/ds_genericprops/props/miningrock_def.json
+++ b/ds_genericprops/props/miningrock_def.json
@@ -2,7 +2,7 @@
 	"channels": [
 		{
 			"zone": 0,
-			"distance": 20.0,
+			"distance": 30.0,
 			"frequency": 30.0,
 			"properties": [
 				"position",

--- a/ds_genericprops/props/miningrock_def.json
+++ b/ds_genericprops/props/miningrock_def.json
@@ -8,8 +8,7 @@
 				"position",
 				"rotation",
 				"scenename",
-				"parent_id",
-				"ore_seed"
+				"parent_id"
 			]
 		},
 		{

--- a/ds_genericprops/props/miningrock_def.json
+++ b/ds_genericprops/props/miningrock_def.json
@@ -8,7 +8,8 @@
 				"position",
 				"rotation",
 				"scenename",
-				"parent_id"
+				"parent_id",
+				"ore_seed"
 			]
 		},
 		{
@@ -18,7 +19,8 @@
 			"properties": [
 				"scenename",
 				"weight",
-				"blocs"
+				"blocs",
+				"ore_seed"
 			]
 		}
 	]

--- a/ds_genericprops/props/palette_container_def.json
+++ b/ds_genericprops/props/palette_container_def.json
@@ -1,0 +1,24 @@
+{
+	"channels": [
+		{
+			"zone": 0,
+			"distance": 150.0,
+			"frequency": 30.0,
+			"properties": [
+				"position",
+				"rotation",
+				"scenename",
+				"parent_id"
+			]
+		},
+		{
+			"zone": 6,
+			"distance": 150.0,
+			"frequency": 3.0,
+			"properties": [
+				"scenename",
+				"content"
+			]
+		}
+	]
+}


### PR DESCRIPTION
## Description

Server-side support for the mining depot + fixes:
- New prop defs `mining_depot` and `palette_container` (replicated properties for the depot and its output crate).
- Replicate the rock `ore_seed` so a fractured piece keeps the same ore field on clients (cut faces match, purity is consistent).
- Subscribe the persistence service to `genericprops:delete_object` so deleted props are removed from the DB.
- +align mining rock zone 0 to 30 m → fixes rocks spawning at world origin

Goes together with the DyingStar (client) mining-depot PR and the services persistence PR.

## Changelog

<!-- CHANGELOG_EN -->
Fix the ore shown on a fractured rock's cut faces so it stays consistent across clients.
<!-- /CHANGELOG_EN -->

<!-- CHANGELOG_FR -->
Correction du minerai visible sur les faces de coupe d'une roche fracturée afin qu'il reste cohérent pour tous les clients.<!-- /CHANGELOG_FR -->
