### PR TITLE
PR 5 - Feat/vehicle prop def

### DIFF
--- a/ds_genericprops/props/vehicle_def.json
+++ b/ds_genericprops/props/vehicle_def.json
@@ -10,7 +10,8 @@
 				"scenename",
 				"parent_id",
 				"pilot_uuid",
-				"steering"
+				"steering",
+				"speed"
 			]
 		},
 		{

--- a/ds_genericprops/props/vehicle_def.json
+++ b/ds_genericprops/props/vehicle_def.json
@@ -12,6 +12,14 @@
 				"pilot_uuid",
 				"steering"
 			]
+		},
+		{
+			"zone": 6,
+			"distance": 200.0,
+			"frequency": 3.0,
+			"properties": [
+				"scenename"
+			]
 		}
 	]
 }

--- a/ds_genericprops/props/vehicle_def.json
+++ b/ds_genericprops/props/vehicle_def.json
@@ -1,0 +1,17 @@
+{
+	"channels": [
+		{
+			"zone": 0,
+			"distance": 200.0,
+			"frequency": 30.0,
+			"properties": [
+				"position",
+				"rotation",
+				"scenename",
+				"parent_id",
+				"pilot_uuid",
+				"steering"
+			]
+		}
+	]
+}


### PR DESCRIPTION
## Description

Replication definition for the `vehicle` prop type, so the server-authoritative vehicle reaches the clients.

- **zone 0** — `position`, `rotation`, `scenename`, `parent_id`, `pilot_uuid`, `steering` (the   live vehicle state).
- **zone 6** — `scenename` (the structural / deletion channel). Required: deletion is sent on  channel 6, so without it the vehicle is removed server-side but lingers on clients  (`Channel 6 not defined`).

Companion to the vehicle feature PR 5 on the `DyingStar` repo.

## Changelog
<!-- CHANGELOG_EN -->
Add the vehicle prop replication definition (state channel + deletion channel).
Add the vehicle prop replication definition (state, deletion channel, and speed).
<!-- /CHANGELOG_EN -->

<!-- CHANGELOG_FR -->
Ajout de la définition de réplication des propriétés du véhicule (canal d'état + canal de suppression).
Ajout de la définition de réplication des propriétés du véhicule (état, canal de suppression et vitesse).
<!-- /CHANGELOG_FR -->
