### PR TITLE
Remove player on gorc when disconnected

### DIFF
--- a/ds_genericprops/src/lib.rs
+++ b/ds_genericprops/src/lib.rs
@@ -488,6 +488,7 @@ impl GenericPropsPlugin {
                 };
 
                 gorc_instances.remove_player(event.player_id).await;
+                gorc_instances.unregister_object(gorc_id).await;
 
                 // TODO create real delete event for servers
                 let mut prop_properties = HashMap::new();


### PR DESCRIPTION
## Description

When player disconnect, the remove_player will unscribe to all subscription, but not delete player from gorc internal database. Now we delete it

## Changelog

Fill in the English entry (required). If this PR has no user-visible change, delete both sections and skip.

<!-- CHANGELOG_EN -->
When player disconnect, the remove_player will unscribe to all subscription, but not delete player from gorc internal database. Now, we delete it. Fix disconnected player seen for new players connected.
<!-- /CHANGELOG_EN -->

French entry (optional — leave the section empty to reuse the English text):

<!-- CHANGELOG_FR -->
Lorsqu'un joueur se déconnecte, la fonction remove_player le désabonne de tous ses abonnements, mais ne le supprime pas de la base de données interne de gorc. Nous le supprimons désormais. Correction du joueur déconnecté visible pour les nouveaux joueurs connectés
<!-- /CHANGELOG_FR -->
