### PR TITLE
Replicate truck cargo_mass, handbrake and total mass

### DIFF
--- a/ds_genericprops/props/vehicle_def.json
+++ b/ds_genericprops/props/vehicle_def.json
@@ -11,7 +11,10 @@
 				"parent_id",
 				"pilot_uuid",
 				"steering",
-				"speed"
+				"speed",
+				"cargo_mass",
+				"handbrake",
+				"mass"
 			]
 		},
 		{


### PR DESCRIPTION
## Description

Add `cargo_mass`, `handbrake` and `mass` to the vehicle zone-0 replication so the
client dashboard/HUD can show the real load, parking-brake state and total weight
(bed cargo + seated players) instead of stale local values.

No standalone user-visible change — it enables the display shipped in DyingStar
`feat/truck-fixes`; both PRs must be merged together.
