### PR TITLE
Fix apartment attribution in the persistence

### DIFF
--- a/ds_genericprops/src/handlers/new_player.rs
+++ b/ds_genericprops/src/handlers/new_player.rs
@@ -225,6 +225,20 @@ println!("plugin genericprops (new_player): found free slot for player {} in bui
                                     "apartments": apartments.clone(),
                                 }));
 
+                                // Wee need to send to update_object_from_external to broadcast the new occupancy to nearby clients and persistance, not needed to send to server godot
+                                events.emit_plugin(
+                                    "genericprops",
+                                    "update_object_from_external",
+                                    &serde_json::json!({
+                                        "object_type": "spawnbuilding",
+                                        "object_uuid": building.uuid,
+                                        "object_data": {
+                                            "available": available - 1,
+                                            "apartments": apartments.clone(),
+                                        },
+                                    }),
+                                ).await?;
+
                                 Some((slot_spawn_position, building.uuid.clone(), apartments))
                             } else {
                                 None


### PR DESCRIPTION
## Description

Fix the apartment attribution store in persistence (it wasn't the case, that's why when restart Horizon, we loose them)

## Changelog

Fill in the English entry (required). If this PR has no user-visible change, delete both sections and skip.

<!-- CHANGELOG_EN -->
Fix the apartment attribution store in persistence (it wasn't the case, that's why when restart Horizon, we loose them)
<!-- /CHANGELOG_EN -->

French entry (optional — leave the section empty to reuse the English text):

<!-- CHANGELOG_FR -->
Correction du stockage persistant des attributions d'appartements (ce n'était pas le cas, c'est pourquoi nous les perdons lors du redémarrage d'Horizon).
<!-- /CHANGELOG_FR -->
