### PR TITLE
Replicate vehicle headlights and player flashlight

### DIFF
--- a/ds_genericprops/props/player_def.json
+++ b/ds_genericprops/props/player_def.json
@@ -13,6 +13,7 @@
 				"head",
 				"perforating",
 				"carrying",
+				"flashlight",
 				"scenename",
 				"name",
 				"parent_id",

--- a/ds_genericprops/props/vehicle_def.json
+++ b/ds_genericprops/props/vehicle_def.json
@@ -14,7 +14,8 @@
 				"speed",
 				"cargo_mass",
 				"handbrake",
-				"mass"
+				"mass",
+				"headlights"
 			]
 		},
 		{


### PR DESCRIPTION
## Description

Add `headlights` to the vehicle replication def and `flashlight` to the player def so the head
lights and the player's torch reach the clients (both toggled with L, server-authoritative).

No standalone user-visible change — it enables the display shipped in DyingStar
`feat/vehicle-headlights-parking`; both PRs must be merged together.
