### PR TITLE
Whitelist carry_prompt on the player so the server can drive the carr…

### DIFF
--- a/ds_genericprops/props/player_def.json
+++ b/ds_genericprops/props/player_def.json
@@ -14,6 +14,7 @@
 				"perforating",
 				"carrying",
 				"flashlight",
+				"carry_prompt",
 				"scenename",
 				"name",
 				"parent_id",


### PR DESCRIPTION
## Description
The carry prompt is now decided by the game server and replicated to the owning client. Add
`carry_prompt` to the player replication whitelist (`player_def.json`) so Horizon forwards it
instead of dropping it. Requires the companion DyingStar PR `fix/carry-line-of-sight`.

## Changelog

<!-- CHANGELOG_EN -->
Replicate the player's server-driven carry prompt to clients.
<!-- /CHANGELOG_EN -->

<!-- CHANGELOG_FR -->
Replication de l'action attraper gérée par le serveur du serveur sur les clients.
<!-- /CHANGELOG_FR -->
