### PR TITLE
miningrock: replicate mineral_id + widen distance to 150m

### DIFF
--- a/ds_genericprops/props/miningrock_def.json
+++ b/ds_genericprops/props/miningrock_def.json
@@ -2,7 +2,7 @@
 	"channels": [
 		{
 			"zone": 0,
-			"distance": 30.0,
+			"distance": 150.0,
 			"frequency": 30.0,
 			"properties": [
 				"position",
@@ -13,7 +13,7 @@
 		},
 		{
 			"zone": 6,
-			"distance": 30.0,
+			"distance": 150.0,
 			"frequency": 3.0,
 			"properties": [
 				"scenename",

--- a/ds_genericprops/props/miningrock_def.json
+++ b/ds_genericprops/props/miningrock_def.json
@@ -19,7 +19,8 @@
 				"scenename",
 				"weight",
 				"blocs",
-				"ore_seed"
+				"ore_seed",
+				"mineral_id"
 			]
 		}
 	]


### PR DESCRIPTION
> Companion to DyingStar-game PR #214 (mining zones). Pushed for review alongside the open GORC ghost investigation.

## Description
Two GORC changes to `ds_genericprops/props/miningrock_def.json` needed by the Mining Zones feature:
- **Widen replication distance 30 → 150 m** (both channels) so a generated rock field is visible as the player approaches, not only within 30 m.
- **Add `mineral_id`** to the zone-6 channel so a per-zone mineral (gold / iron / cryptonite) reaches clients and is applied to the rock look.

## Changelog
<!-- CHANGELOG_EN -->
- feat: replicate `mineral_id` on miningrock
- tweak: miningrock GORC distance 30 → 150 m
<!-- /CHANGELOG_EN -->

<!-- CHANGELOG_FR -->
- Feat : répliquer `mineral_id` sur miningrock
- Modification : distance GORC de miningrock 30 → 150 m
<!-- /CHANGELOG_FR -->
