### PR TITLE
feat(genericprops): whitelist "doors" on the vehicle replication def

### DIFF
--- a/ds_genericprops/props/vehicle_def.json
+++ b/ds_genericprops/props/vehicle_def.json
@@ -15,7 +15,8 @@
 				"cargo_mass",
 				"handbrake",
 				"mass",
-				"headlights"
+				"headlights",
+				"doors"
 			]
 		},
 		{


### PR DESCRIPTION
## Description

Whitelist the **`doors`** property on the `vehicle` replication def (`ds_genericprops/props/vehicle_def.json`, channel zone 0).

Vehicles now keep a per-door open/closed state on the game server, replicated as a `{door_id: bool}` map. A property that isn't whitelisted is dropped by GORC, so without this entry remote clients never see doors open or close. The value is an opaque map — Horizon forwards it verbatim (no per-field typing), so nothing else changes server-side.

Pairs with the DyingStar-game PR *"real 3D (GLB) model support — wheels, steering, doors, handles, collision"*.

<!-- No standalone user-visible change (enabling def only); changelog lives in the client PR. -->
