### PR TITLE
feat(props): replicate the vehicle engine and horn state

### DIFF
--- a/ds_genericprops/props/vehicle_def.json
+++ b/ds_genericprops/props/vehicle_def.json
@@ -16,6 +16,9 @@
 				"handbrake",
 				"mass",
 				"headlights",
+				"engine",
+				"horn",
+				"horn_special",
 				"doors"
 			]
 		},


### PR DESCRIPTION
## Description

Whitelist three new properties on the vehicle channel: `engine` (ignition), `horn` (the held horn) and `horn_special` (the one-shot special horn).

Without them Horizon drops the properties, so the game server's engine and horn state never reaches the clients around the vehicle — only the driver would get any feedback. Companion to DyingStar-game PR "feat(vehicle): audio SFX + engine ignition, horns and hand-brake state".

## Changelog

<!-- CHANGELOG_EN -->
The state of a vehicle's engine and horns is now replicated: every player around a truck hears it start, idle, rev and honk.
<!-- /CHANGELOG_EN -->

<!-- CHANGELOG_FR -->
L'état du moteur et des klaxons d'un véhicule est désormais répliqué : tous les joueurs autour d'un camion l'entendent démarrer, tourner au ralenti, monter en régime et klaxonner.
<!-- /CHANGELOG_FR -->