### PR TITLE
fix(dev): persist prop deletions in the local dev config

### DIFF
--- a/plugins.toml
+++ b/plugins.toml
@@ -64,6 +64,7 @@ subscribe = [
     "plugin:genericprops:create_object_from_gameserver",
     "plugin:genericprops:update_object",
     "plugin:genericprops:update_object_from_external",
+    "plugin:genericprops:delete_object",
     "plugin:bridge_persistence:get_all_items",
     "plugin:bridge_persistence:player_spawn",
 ]


### PR DESCRIPTION
## Description

One line. `plugins.toml` — the **local dev** config — never subscribed the persistence bridge to `genericprops:delete_object`, while `.docker/plugins.toml` (the image shipped to preprod/prod) always did.

Deleting a prop therefore removed it from the world and from the GORC, but **left its row in the database**: every deleted object came back to life on the next server restart. Phantom props pile up locally — the same object spawned, deleted and resurrected, restart after restart — and there is no way to be rid of one short of a manual `cqlsh` purge. It bit us today: two stray mining depots kept reappearing next to the city one, and operating the screen of one while the ore sat on the belt of another made the depot look broken.

**Production and preprod were never affected** — only the local dev loop, which is precisely where the admin cleanup tool is used.

The other three differences between the two files are deliberate dev settings (`servers_mode`, `split_rule`, `log_level) and are left alone.

## Changelog

Delete both sections — no user-visible change (local dev configuration only).