### PR TITLE
feat(player): whitelist stance / head_yaw / per-seat occupancy for animated characters

### DIFF
--- a/ds_genericprops/props/player_def.json
+++ b/ds_genericprops/props/player_def.json
@@ -12,6 +12,7 @@
 				"tools",
 				"head",
 				"head_yaw",
+				"stance",
 				"perforating",
 				"carrying",
 				"flashlight",

--- a/ds_genericprops/props/player_def.json
+++ b/ds_genericprops/props/player_def.json
@@ -11,6 +11,7 @@
 				"action",
 				"tools",
 				"head",
+				"head_yaw",
 				"perforating",
 				"carrying",
 				"flashlight",

--- a/ds_genericprops/props/vehicle_def.json
+++ b/ds_genericprops/props/vehicle_def.json
@@ -18,7 +18,8 @@
 				"engine",
 				"horn",
 				"horn_special",
-				"doors"
+				"doors",
+				"seats"
 			]
 		},
 		{


### PR DESCRIPTION
## Description

Whitelists three replicated properties the game's **animated characters** need (pairs with **DyingStar#257**), so they reach clients instead of being dropped:

- **`seats`** (vehicle) — per-seat occupancy map, for the correct "occupied" prompt on **passenger** seats (before, only the driver's `pilot_uuid` was replicated).
- **`head_yaw`** (player) — a **seated** player's free-look yaw, so a seated avatar's head can follow the look sideways.
- **`stance`** (player) — standing / crouched / prone, so remotes show the crouch/crawl pose.

Def-only changes (`player_def.json`, `vehicle_def.json`). ⚠️ Deploy **in lockstep** with DyingStar#257.

## Changelog

<!-- CHANGELOG_EN -->
Replicate the player stance (crouch/prone) and seated look yaw, plus per-seat vehicle occupancy, so other players see them.
<!-- /CHANGELOG_EN -->

<!-- CHANGELOG_FR -->
Réplique la posture du joueur (accroupi/allongé) et le yaw du regard assis, ainsi que l'occupation des sièges de véhicule, pour que les autres joueurs les voient.
<!-- /CHANGELOG_FR -->
