### PR TITLE
fix(game_server): spawn update_player_id work on a captured runtime handle

### DIFF
--- a/horizon.diff
+++ b/horizon.diff
@@ -216,13 +216,16 @@ diff -urN --strip-trailing-cr '--exclude=target' '--exclude=.git' '--exclude=log
 diff -urN --strip-trailing-cr '--exclude=target' '--exclude=.git' '--exclude=logs' '--exclude=*.sock' a/crates/game_server/src/server/core.rs b/crates/game_server/src/server/core.rs
 --- a/crates/game_server/src/server/core.rs	2026-04-25 00:31:25.636627972 +0200
 +++ b/crates/game_server/src/server/core.rs	2025-12-22 09:27:42.428258303 +0100
-@@ -547,6 +547,44 @@
+@@ -547,6 +547,51 @@
              .await
              .map_err(|e| ServerError::Internal(e.to_string()))?;
  
 +        // Register handler to update player_id in connection manager
 +        // This allows plugins to replace the temporary connection-level player_id
 +        // with a permanent database player_id after authentication
++        // Capture the runtime handle HERE: register_core_handlers is async, so this line always runs
++        // inside the host runtime, while the handler below is invoked from a plugin's own thread.
++        let rt_handle = tokio::runtime::Handle::current();
 +        let connection_manager_for_update = self.connection_manager.clone();
 +        self.horizon_event_system
 +            .on_core_async("update_player_id", move |event: serde_json::Value| {
@@ -235,9 +238,13 @@ diff -urN --strip-trailing-cr '--exclude=target' '--exclude=.git' '--exclude=log
 +                let new_player_id = serde_json::from_value::<horizon_event_system::PlayerId>(event["new_player_id"].clone());
 +
 +                if let (Ok(old_player_id), Ok(new_player_id)) = (old_player_id, new_player_id) {
-+                    // Spawn a dedicated thread with its own runtime to handle the async work
-+                    // This is necessary because on_core_async handlers don't have a guaranteed tokio runtime context
-+                    tokio::spawn(async move {
++                    // Spawn through the CAPTURED handle, never tokio::spawn: this closure runs on the
++                    // emitting plugin's thread, which has no runtime in its thread-local, so
++                    // tokio::spawn panics with "there is no reactor running" and aborts the whole
++                    // process. Handle::spawn is callable from any thread and schedules onto the host
++                    // runtime. (Sibling handlers use Handle::try_current(), which merely skips the
++                    // work when it is absent — silent, so not a model to copy here.)
++                    rt_handle.spawn(async move {
 +                        // Get the connection_id for this player
 +                        if let Some(connection_id) = conn_mgr.get_connection_id_by_player(old_player_id).await {
 +                            // Update the player_id stored in the connection


### PR DESCRIPTION
## Description

Horizon aborts every time a player connects, and it is intermittent — which is why it comes and goes.

The `update_player_id` handler that `horizon.diff` adds to `crates/game_server/src/server/core.rs` calls `tokio::spawn`. But that handler is invoked from the **emitting plugin's** thread (`ds_player_authentication`), which has no tokio runtime in its thread-local. `tokio::spawn` then panics, and because the panic crosses the plugin boundary the whole process dies:

```
👋 Player ed2d4fe6-… connected
🔄 Received update_player_id event: …
thread '<unnamed>' panicked at crates/game_server/src/server/core.rs:567:21:
there is no reactor running, must be called from the context of a Tokio 1.x runtime
fatal runtime error: Rust cannot catch foreign exceptions, aborting
```

From a client's point of view: it spawns, Horizon dies, and the player gets a grey screen followed by `ERROR 1337`. Whether it triggers depends on which thread emits the event, hence the intermittence.

The handler's own comment already announced *"Spawn a dedicated thread with its own runtime … because on_core_async handlers don't have a guaranteed tokio runtime context"*, so the intent was right — only the call was wrong.

### Fix

Capture `tokio::runtime::Handle::current()` in `register_core_handlers` (an `async fn`, so it always runs inside the host runtime) and use `handle.spawn()`, which is callable from any thread and schedules onto the host runtime.

### Why not `Handle::try_current()`

The three sibling handlers (`auth_status_set` and friends, l.472/513/602) guard with `Handle::try_current()`. That avoids the panic, but when the runtime is absent it simply **skips the work, silently** — so it was not a model to copy here. Those three may deserve the same treatment in a follow-up, since today they are probably no-ops on that path.

### Not a tokio version drift

Worth writing down, because it looks exactly like the drift fixed by the `=1.52.1` pin. It is not: the root `Cargo.toml` is a **workspace** whose eight `ds_*` plugins are members, so **only the root lock counts** — and it agrees with `Horizon/Cargo.toml` (both 1.52.1). The `Cargo.lock` files sitting in `ds_game_server/`, `ds_props/` etc. show 1.47.1/1.48.0 but **Cargo ignores them**; they are leftovers and are actively misleading when diagnosing. Removing them from the repo would save the next person some time.

### Testing

Verified locally (skaffold/minikube, game server run from the editor) against a game server plus **five NPC clients connecting at once**: no panic, no pod restart, and `Updated player_id in connection` now completes. Before the fix, a single player connecting was enough to kill Horizon.

## Changelog

<!-- CHANGELOG_EN -->
- Fixed a crash that could take the server down whenever a player connected, leaving clients on a grey screen with `ERROR 1337`.
<!-- /CHANGELOG_EN -->

<!-- CHANGELOG_FR -->
- Correction d'un plantage qui pouvait faire tomber le serveur à chaque connexion d'un joueur, laissant les clients sur un écran gris avec l'erreur 1337.
<!-- /CHANGELOG_FR -->
